### PR TITLE
Adding ssl cert

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       - "8501:8501"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.tsm-browser-app.rule=Host(`ktc.armada247.com`)"
+      - "traefik.http.routers.tsm-browser-app.rule=Host(`localhost`)"
       - "traefik.http.routers.tsm-browser-app.entrypoints=websecure"
       - "traefik.http.routers.tsm-browser-app.tls.certresolver=myresolver"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entryPoints.websecure.address=:443"
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
-      - "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       - "--certificatesresolvers.myresolver.acme.email=communication@moloko-mokubedi.co.za"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
@@ -28,6 +28,6 @@ services:
       - "8501:8501"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.tsm-browser-app.rule=Host(`localhost`)"
+      - "traefik.http.routers.tsm-browser-app.rule=Host(`ktc.armada247.com`)"
       - "traefik.http.routers.tsm-browser-app.entrypoints=websecure"
       - "traefik.http.routers.tsm-browser-app.tls.certresolver=myresolver"


### PR DESCRIPTION
Traefik successfully auto generates the SSL cert, change `"traefik.http.routers.tsm-browser-app.rule=Host(`localhost`)"` to `"traefik.http.routers.tsm-browser-app.rule=Host(`<domain_name>`)"` where <domain_name> is the domain name (with subdomain) pointing to the machine.